### PR TITLE
feat(api): add webhook routes for Clerk and PayPal (#7)

### DIFF
--- a/app/api/webhooks/clerk/route.ts
+++ b/app/api/webhooks/clerk/route.ts
@@ -1,0 +1,118 @@
+/* eslint-disable camelcase */
+
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { Webhook } from "svix";
+import { clerkClient } from "@clerk/nextjs";
+import { WebhookEvent } from "@clerk/nextjs/server";
+
+import { createUser, deleteUser, updateUser } from "@/lib/actions/user.actions";
+
+export async function POST(req: Request) {
+	/* you can find this in the Clerk Dashboard -> Webhooks -> choose the webhook */
+	const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET;
+
+	if (!WEBHOOK_SECRET) {
+		throw new Error(
+			"Please add WEBHOOK_SECRET from the Clerk Dashboard to .env or .env.local."
+		);
+	}
+
+	/* get the headers */
+	const headerPayload = headers();
+	const svix_id = headerPayload.get("svix-id");
+	const svix_timestamp = headerPayload.get("svix-timestamp");
+	const svix_signature = headerPayload.get("svix-signature");
+
+	/* if there are no headers, error out */
+	if (!svix_id || !svix_timestamp || !svix_signature) {
+		return new Response("Error occured -- no svix headers", {
+			status: 400,
+		});
+	}
+
+	/* get the body */
+	const payload = await req.json();
+	const body = JSON.stringify(payload);
+
+	/* create a new Svix instance with your secret */
+	const wh = new Webhook(WEBHOOK_SECRET);
+
+	let evt: WebhookEvent;
+
+	/* verify the payload with the headers */
+	try {
+		evt = wh.verify(body, {
+			"svix-id": svix_id,
+			"svix-timestamp": svix_timestamp,
+			"svix-signature": svix_signature,
+		}) as WebhookEvent;
+	} catch (err) {
+		console.error("Error verifying webhook:", err);
+		return new Response("Error occured", {
+			status: 400,
+		});
+	}
+
+	/* get the ID and type */
+	const { id } = evt.data;
+	const eventType = evt.type;
+
+	/* create */
+	if (eventType === "user.created") {
+		const { id, email_addresses, image_url, first_name, last_name, username } =
+			evt.data;
+
+		const user = {
+			clerkId: id,
+			email: email_addresses[0].email_address,
+			username: username!,
+			firstName: first_name,
+			lastName: last_name,
+			photo: image_url,
+		};
+
+		const newUser = await createUser(user);
+
+		/* set public metadata */
+		if (newUser) {
+			await clerkClient.users.updateUserMetadata(id, {
+				publicMetadata: {
+					userId: newUser._id,
+				},
+			});
+		}
+
+		return NextResponse.json({ message: "OK", user: newUser });
+	}
+
+	/* update */
+	if (eventType === "user.updated") {
+		const { id, image_url, first_name, last_name, username } = evt.data;
+
+		const user = {
+			firstName: first_name,
+			lastName: last_name,
+			username: username!,
+			photo: image_url,
+		};
+
+		const updatedUser = await updateUser(id, user);
+
+		return NextResponse.json({ message: "OK", user: updatedUser });
+	}
+
+	/* delete */
+	if (eventType === "user.deleted") {
+		const { id } = evt.data;
+
+		const deletedUser = await deleteUser(id!);
+
+		return NextResponse.json({ message: "OK", user: deletedUser });
+	}
+
+	console.log(`Webhook with and ID of ${id} and type of ${eventType}`);
+	console.log("Webhook body:", body);
+
+	return new Response("", { status: 200 });
+}

--- a/app/api/webhooks/paypal/route.ts
+++ b/app/api/webhooks/paypal/route.ts
@@ -1,0 +1,3 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"qs": "^6.12.0",
 		"react": "^18",
 		"react-dom": "^18",
+		"svix": "^1.21.0",
 		"tailwind-merge": "^2.2.1",
 		"tailwindcss-animate": "^1.0.7"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.2.0(react@18.2.0)
+  svix:
+    specifier: ^1.21.0
+    version: 1.21.0
   tailwind-merge:
     specifier: ^2.2.1
     version: 2.2.1
@@ -789,6 +792,10 @@ packages:
   /@rushstack/eslint-patch@1.7.2:
     resolution: {integrity: sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==}
     dev: true
+
+  /@stablelib/base64@1.0.1:
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+    dev: false
 
   /@swc/helpers@0.5.2:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
@@ -1630,6 +1637,10 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+    dev: false
+
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
@@ -1938,6 +1949,10 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
+
+  /fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+    dev: false
 
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -2765,6 +2780,18 @@ packages:
     resolution: {integrity: sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==}
     dev: false
 
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
@@ -3047,6 +3074,10 @@ packages:
       side-channel: 1.0.6
     dev: false
 
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+    dev: false
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -3164,6 +3195,10 @@ packages:
       es-errors: 1.3.0
       set-function-name: 2.0.2
     dev: true
+
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: false
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3455,6 +3490,27 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  /svix-fetch@3.0.0:
+    resolution: {integrity: sha512-rcADxEFhSqHbraZIsjyZNh4TF6V+koloX1OzZ+AQuObX9mZ2LIMhm1buZeuc5BIZPftZpJCMBsSiBaeszo9tRw==}
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /svix@1.21.0:
+    resolution: {integrity: sha512-aKZVf1Jc962frT/Hpz064mtpDgu80dBK1B/+qVY5PKYdYIzOpvdiWn3pqQNjCTN8T4vwg9oc4xl1xTd1ka3agQ==}
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      es6-promise: 4.2.8
+      fast-sha256: 1.3.0
+      svix-fetch: 3.0.0
+      url-parse: 1.5.10
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /swr@2.2.0(react@18.2.0):
     resolution: {integrity: sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==}
     peerDependencies:
@@ -3548,6 +3604,10 @@ packages:
     resolution: {integrity: sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==}
     dependencies:
       to-no-case: 1.0.2
+    dev: false
+
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: false
 
   /tr46@4.1.1:
@@ -3682,6 +3742,13 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+    dev: false
+
   /use-callback-ref@1.3.1(@types/react@18.2.64)(react@18.2.0):
     resolution: {integrity: sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==}
     engines: {node: '>=10'}
@@ -3734,9 +3801,17 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+    dev: false
+
+  /whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
     dev: false
 
   /whatwg-url@13.0.0:
@@ -3745,6 +3820,13 @@ packages:
     dependencies:
       tr46: 4.1.1
       webidl-conversions: 7.0.0
+    dev: false
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: false
 
   /which-boxed-primitive@1.0.2:


### PR DESCRIPTION
This commit adds new route files for handling webhooks from Clerk and PayPal. The Clerk webhook route handles user creation, update, and deletion events. The PayPal webhook route is currently empty.

Changes also include adding the `svix` package as a dependency in `package.json` and updating the `pnpm-lock.yaml` file with the corresponding version of `svix`.

The commit message follows the conventional commits specification with a description of less than 50 characters and in lowercase.