### PR TITLE
feat: update lucide-react and next-cloudinary dependencies

### DIFF
--- a/components/shared/checkout.tsx
+++ b/components/shared/checkout.tsx
@@ -50,6 +50,8 @@ export const Checkout = ({
 
 			const approval = await response.json();
 
+			router.refresh();
+
 			console.log("Approval data: ", approval);
 
 			setTimeout(() => {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
 		"class-variance-authority": "^0.7.0",
 		"cloudinary": "^2.0.3",
 		"clsx": "^2.1.0",
-		"lucide-react": "^0.350.0",
+		"lucide-react": "^0.354.0",
 		"mongodb": "^6.4.0",
 		"mongoose": "^8.2.1",
 		"next": "14.1.3",
-		"next-cloudinary": "^6.2.0",
+		"next-cloudinary": "^6.2.1",
 		"qs": "^6.12.0",
 		"react": "^18",
 		"react-dom": "^18",
@@ -42,11 +42,11 @@
 		"@types/qs": "^6.9.12",
 		"@types/react": "^18",
 		"@types/react-dom": "^18",
-		"autoprefixer": "^10.0.1",
+		"autoprefixer": "^10.4.18",
 		"eslint": "^8",
 		"eslint-config-next": "14.1.3",
 		"postcss": "^8",
-		"tailwindcss": "^3.3.0",
+		"tailwindcss": "^3.4.1",
 		"typescript": "^5"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ dependencies:
     specifier: ^2.1.0
     version: 2.1.0
   lucide-react:
-    specifier: ^0.350.0
-    version: 0.350.0(react@18.2.0)
+    specifier: ^0.354.0
+    version: 0.354.0(react@18.2.0)
   mongodb:
     specifier: ^6.4.0
     version: 6.4.0
@@ -57,8 +57,8 @@ dependencies:
     specifier: 14.1.3
     version: 14.1.3(react-dom@18.2.0)(react@18.2.0)
   next-cloudinary:
-    specifier: ^6.2.0
-    version: 6.2.0(next@14.1.3)(react@18.2.0)
+    specifier: ^6.2.1
+    version: 6.2.1(next@14.1.3)(react@18.2.0)
   qs:
     specifier: ^6.12.0
     version: 6.12.0
@@ -101,7 +101,7 @@ devDependencies:
     specifier: ^18
     version: 18.2.21
   autoprefixer:
-    specifier: ^10.0.1
+    specifier: ^10.4.18
     version: 10.4.18(postcss@8.4.35)
   eslint:
     specifier: ^8
@@ -113,7 +113,7 @@ devDependencies:
     specifier: ^8
     version: 8.4.35
   tailwindcss:
-    specifier: ^3.3.0
+    specifier: ^3.4.1
     version: 3.4.1
   typescript:
     specifier: ^5
@@ -2915,8 +2915,8 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /lucide-react@0.350.0(react@18.2.0):
-    resolution: {integrity: sha512-5IZVKsxxG8Nn81gpsz4XLNgCAXkppCh0Y0P0GLO39h5iVD2WEaB9of6cPkLtzys1GuSfxJxmwsDh487y7LAf/g==}
+  /lucide-react@0.354.0(react@18.2.0):
+    resolution: {integrity: sha512-qI0x/hhcuHieaUUxFejesm5T/ditszQ2x1gUkqKnTMZRAOdxT2nGzbOFYrhc0wRjuA2MN1o5JCrcRPYcHH3l8A==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
     dependencies:
@@ -3104,8 +3104,8 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next-cloudinary@6.2.0(next@14.1.3)(react@18.2.0):
-    resolution: {integrity: sha512-yr3uKtfNfJ6ybd97j/lkL7qCGMDifysuelE8I9Xu5tCgn+86XGy1pVEPLQ0XUSG0wYaKC5LxnRgkD+0BPB5lKw==}
+  /next-cloudinary@6.2.1(next@14.1.3)(react@18.2.0):
+    resolution: {integrity: sha512-ixHXTk5/Ftmo0x2m1Zggs5lq8EwZ15IUDeghaG6AVE2cXZUAm3NViE+CFS8mmtdov5YQojgicFsBEWWPkEe9Kg==}
     peerDependencies:
       next: ^12 || ^13 || ^14
       react: ^17 || ^18


### PR DESCRIPTION
The code changes include updating the lucide-react dependency from version 0.350.0 to 0.354.0 and the next-cloudinary dependency from version 6.2.0 to 6.2.1 in package.json and pnpm-lock.yaml files.

This commit follows the conventional commits specification with a description of less than 50 characters and in lowercase.